### PR TITLE
add pan/zoom functionality with panzoom npm package. Implements #18.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2273,6 +2273,14 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
+    "amator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/amator/-/amator-1.1.0.tgz",
+      "integrity": "sha1-CMa2C8k67Cthu/wMTWd9MDI8wPE=",
+      "requires": {
+        "bezier-easing": "^2.0.3"
+      }
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -2951,6 +2959,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha1-wE3+i5JtbsrKGBPWn/F5t8ICXYY="
     },
     "bfj": {
       "version": "6.1.2",
@@ -9888,6 +9901,11 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
+    "ngraph.events": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-1.2.1.tgz",
+      "integrity": "sha512-D4C+nXH/RFxioGXQdHu8ELDtC6EaCiNsZtih0IvyGN81OZSUby4jXoJ5+RNWasfsd0FnKxxpAROyUMzw64QNsw=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -10474,6 +10492,16 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
       "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
       "dev": true
+    },
+    "panzoom": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/panzoom/-/panzoom-9.2.1.tgz",
+      "integrity": "sha512-jFEpjlttb++pJfpODp76VAPh5RpQynRqrtlgVvvCHFQEmH0y+lQ17fzL/vnnAeNWZgc2b7eI1fNgug7M1TvT2w==",
+      "requires": {
+        "amator": "^1.1.0",
+        "ngraph.events": "^1.0.0",
+        "wheel": "^1.0.0"
+      }
     },
     "parallel-transform": {
       "version": "1.2.0",
@@ -14257,6 +14285,11 @@
         "tr46": "^1.0.1",
         "webidl-conversions": "^4.0.2"
       }
+    },
+    "wheel": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wheel/-/wheel-1.0.0.tgz",
+      "integrity": "sha512-XiCMHibOiqalCQ+BaNSwRoZ9FDTAvOsXxGHXChBugewDj7HC8VBIER71dEOiRH1fSdLbRCQzngKTSiZ06ZQzeA=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@mdi/font": "^3.6.95",
     "core-js": "^3.4.4",
+    "panzoom": "^9.2.1",
     "register-service-worker": "^1.6.2",
     "roboto-fontface": "*",
     "vue": "^2.6.10",

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -1,15 +1,16 @@
 <template>
-  <div class="background-wrapper">
+  <div class="background-wrapper" id="background">
     <ImageProcessor @imageSampled='onImageSampled' :imageUrl='imageUrl'></ImageProcessor>
     <svg class="preview-svg" viewBox="0 0 200 100">
-      <rect x="0" y="0" width="200" height="100" stroke="gray" fill="none" />
-      <rect x="10" y="10" width="50" height="50" fill="black" />
+      <g id="preview">
+      </g>
     </svg>
   </div>
 </template>
 
 <script>
 import ImageProcessor from './ImageProcessor.vue';
+import panzoom from '../../node_modules/panzoom';
 
 function drawToSvg(imageData, svg, x, y) {
   /* Takes an ImageData object and an SVG element, and draws the
@@ -64,8 +65,11 @@ export default {
   },
   methods: {
     onImageSampled(imageData) {
-      const svgElement = document.getElementsByClassName('preview-svg')[0];
+      const svgElement = document.querySelector('#preview');
       drawToSvg(imageData, svgElement, 80, 40);
+
+      const draggableElement = document.querySelector('#preview');
+      panzoom(draggableElement);
     },
   },
 };

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -9,8 +9,8 @@
 </template>
 
 <script>
+import panzoom from 'panzoom';
 import ImageProcessor from './ImageProcessor.vue';
-import panzoom from '../../node_modules/panzoom';
 
 function drawToSvg(imageData, svg, x, y) {
   /* Takes an ImageData object and an SVG element, and draws the
@@ -67,10 +67,11 @@ export default {
     onImageSampled(imageData) {
       const svgElement = document.querySelector('#preview');
       drawToSvg(imageData, svgElement, 80, 40);
-
-      const draggableElement = document.querySelector('#preview');
-      panzoom(draggableElement);
     },
+  },
+  mounted() {
+    const draggableElement = document.querySelector('#preview');
+    panzoom(draggableElement);
   },
 };
 </script>


### PR DESCRIPTION
Brings in https://github.com/anvaka/panzoom as a dependency.

 Pretty simple -- just bind an element (can't be the root `<svg>` element) with `panzoom` function. Works on mobile.