### PR TITLE
fixes a console error that would appear when zooming on a touch screen

### DIFF
--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -72,4 +72,9 @@ export default {
   width: 100%;
   height: 100%;
 }
+
+#draggable {
+  touch-action: none;
+}
+
 </style>


### PR DESCRIPTION
A stream of errors that said
```
[Intervention] Unable to preventDefault inside passive event
listener due to target being treated as passive. See
https://www.chromestatus.com/features/5093566007214080
```
 would sometimes appear on Chrome when zooming the preview with a touch screen. Fix is to
apply the `touch-action: none` style onto the element being transformed, from [this issue](https://github.com/bevacqua/dragula/issues/468#issuecomment-485819336).