### PR TITLE
Bind the 'panzoom' function to the draggable preview once

### DIFF
--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -44,13 +44,15 @@ export default {
   methods: {
     onImageSampled(imageData) {
       this.imageData = imageData;
-      const draggableElement = document.querySelector('#draggable');
-      panzoom(draggableElement);
     },
     getColor(x, y) {
       const index = 4 * (y * this.imageData.width + x);
       const [r, g, b, a] = this.imageData.data.slice(index, index + 4);
       return `rgba(${r}, ${g}, ${b}, ${a / 256})`;
+    },
+    mount() {
+      const draggableElement = document.querySelector('#draggable');
+      panzoom(draggableElement);
     },
   },
 };

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -50,10 +50,11 @@ export default {
       const [r, g, b, a] = this.imageData.data.slice(index, index + 4);
       return `rgba(${r}, ${g}, ${b}, ${a / 256})`;
     },
-    mount() {
-      const draggableElement = document.querySelector('#draggable');
-      panzoom(draggableElement);
-    },
+  },
+
+  mounted() {
+    const draggableElement = document.querySelector('#draggable');
+    panzoom(draggableElement);
   },
 };
 </script>


### PR DESCRIPTION
Fix from previous commit that was lost in merge conflict resolution.
panzoom was being called every time an image was uploaded, meaning it
would get bound multiple times. This puts the panzoom call in Preview's
mount(), so it only gets called when the component is loaded. 