### PR TITLE
fix thin grey border appearing between boxes

### DIFF
--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -3,6 +3,7 @@
     <ImageProcessor @imageSampled='onImageSampled' :imageUrl='imageUrl'></ImageProcessor>
     <div id="draggable">
       <svg
+        shape-rendering="crispEdges"
         v-if="imageData"
         class="preview-svg"
         :viewBox="`0 0 ${imageData.width} ${imageData.height}`"


### PR DESCRIPTION
There was a grey border between each SVG element in the image preview. Fixed by adding the attribute
```
shape-rendering="crispEdges"
```
to the `<svg>` element in Preview.vue.