### PR TITLE
Auto-detect proportions of uploaded images

### DIFF
--- a/src/components/ImageProcessor.vue
+++ b/src/components/ImageProcessor.vue
@@ -10,32 +10,42 @@ import LegoData from '@/LegoData';
 
 export default {
   name: 'ImageProcessor',
-  props: ['imageUrl'],
+  props: ['imageUrl', 'imageWidth', 'imageHeight'],
+  methods: {
+    sampleImage() {
+      // single method to reload image, so we can reload the image
+      // every time the URL *or* the dimensions change.
+      if (this.imageUrl === '') return; // only attempt to process image if a URL is set
 
-  watch: {
-    imageUrl(url) {
-      let pixelData = [];
       const ctx = document.getElementById('processing-canvas').getContext('2d');
       ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
       const img = new Image();
       const self = this;
 
       img.onload = function sampleImage() {
-        const width = document.getElementById('widthSetting').value;
-        const height = document.getElementById('heightSetting').value;
+        const width = self.imageWidth;
+        const height = self.imageHeight;
         ctx.drawImage(img, 0, 0, width, height);
-        pixelData = ctx.getImageData(0, 0, width, height);
+        const pixelData = ctx.getImageData(0, 0, width, height);
 
         const legoData = new LegoData(pixelData);
         // Adjust each pixel to the closest LEGO color
         legoData.data = colorMatch(legoData.data);
 
         self.$emit('imageSampled', legoData);
-        // since we've already loaded the image, no need to keep the
-        // object URL anymore
-        URL.revokeObjectURL(url);
       };
-      img.src = url;
+      img.src = this.imageUrl;
+    },
+  },
+  watch: {
+    imageUrl() {
+      this.sampleImage();
+    },
+    imageWidth() {
+      this.sampleImage();
+    },
+    imageHeight() {
+      this.sampleImage();
     },
   },
 };

--- a/src/components/OpenImage.vue
+++ b/src/components/OpenImage.vue
@@ -47,8 +47,6 @@ export default {
       const imageUrl = URL.createObjectURL(this.fileUpload);
       this.$emit('change', imageUrl);
       // this.$emit('delete');
-      // Need to wait until after load to do this
-      // URL.revokeObjectURL(imageUrl);
     },
   },
   data() {
@@ -64,7 +62,6 @@ export default {
         sample3,
       ],
       fileUpload: null,
-
     };
   },
 

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -71,7 +71,7 @@ export default {
           this.imageHeight = Math.floor(this.minEdgeLength * aspectRatio);
         } else if (tmpImg.height < tmpImg.width) {
           this.imageHeight = this.minEdgeLength;
-          this.imageWidth = Math.floor(this.minEdgeLength * aspectRatio);
+          this.imageWidth = Math.floor(this.minEdgeLength / aspectRatio);
         } else {
           this.imageWidth = this.minEdgeLength;
           this.imageHeight = this.minEdgeLength;

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -15,24 +15,20 @@
               <v-text-field
               label="Width"
               id="widthSetting"
-              placeholder="64"
               type="number"
-              v-model="imageWidth"
-              @change="validateWidth"
-              min=0
-              max=5000
+              v-model.number.lazy ="imageWidth"
+              min=1
+              max=100
             ></v-text-field>
             </v-flex>
             <v-flex xs3 style="margin: 24px;">
             <v-text-field
               label="Height"
               id="heightSetting"
-              placeholder="64"
-              v-model="imageHeight"
-              @change="validateHeight"
+              v-model.number.lazy ="imageHeight"
               type="number"
-              min=0
-              max=5000
+              min=1
+              max=100
             ></v-text-field>
           </v-flex>
         </v-layout>
@@ -67,48 +63,26 @@ export default {
       // we briefly unpack the image here from its url to automatically
       // determine what the proportions of the transformed image should be
       const tmpImg = new Image();
-      const self = this;
+      // const self = this;
       tmpImg.onload = () => {
         const aspectRatio = tmpImg.height / tmpImg.width;
         if (tmpImg.height > tmpImg.width) {
-          this.imageWidth = self.minEdgeLength;
-          this.imageHeight = Math.floor(self.minEdgeLength * aspectRatio);
+          this.imageWidth = this.minEdgeLength;
+          this.imageHeight = Math.floor(this.minEdgeLength * aspectRatio);
         } else if (tmpImg.height < tmpImg.width) {
-          this.imageHeight = self.minEdgeLength;
-          this.imageWidth = Math.floor(self.minEdgeLength * aspectRatio);
+          this.imageHeight = this.minEdgeLength;
+          this.imageWidth = Math.floor(this.minEdgeLength * aspectRatio);
         } else {
-          this.imageWidth = self.minEdgeLength;
-          this.imageHeight = self.minEdgeLength;
+          this.imageWidth = this.minEdgeLength;
+          this.imageHeight = this.minEdgeLength;
         }
-        self.imageUrl = data;
+        this.imageUrl = data;
       };
       tmpImg.src = data;
     },
     onImageSampled(imageData) {
       this.imageData = imageData;
       this.$emit('imageLoaded', imageData);
-    },
-    validateWidth() {
-      if (typeof this.imageWidth === 'string') {
-        this.imageWidth = parseInt(this.imageWidth, 10);
-      }
-      if (this.imageWidth < this.minWidth || Number.isNaN(this.imageWidth) || typeof this.imageWidth === 'undefined') {
-        this.imageWidth = this.minWidth;
-      }
-      if (this.imageWidth > this.maxWidth) {
-        this.imageWidth = this.maxWidth;
-      }
-    },
-    validateHeight() {
-      if (typeof this.imageHeight === 'string') {
-        this.imageHeight = parseInt(this.imageHeight, 10);
-      }
-      if (this.imageHeight < this.minHeight) {
-        this.imageHeight = this.minHeight;
-      }
-      if (this.imageHeight > this.maxHeight) {
-        this.imageHeight = this.maxHeight;
-      }
     },
     ImageDelete() {
       // this.$emit('imageLoaded', );


### PR DESCRIPTION
This makes a couple large changes to how the image data is passed
between Settings and ImageProcessor. imageWidth and imageHeight are
now data attributes of Settings that are bound via v-model
to the v-text-field elements, which are in turn passed down
as props to ImageProcessor. Image size detection is now done
in Settings right before the imageUrl is passed down to
ImageProcessor, but this necessarily entails loading the
image data from the objectURL twice, once to get the image size
to set it in Settings, and once to use the data in the draw call
in ImageProcessor. For loading large images this (might) have
some detrimental effect, so comments are welcome.

ImageProcessor now uses the props passed down to it from Settings
to determine the sizes used in the drawImage calls, as opposed
to looking at the value attribute of the v-text-field elements.

Some basic input validation is performed on imageHeight and
imageWidth in Settings with the new min{height, Width} data
attributes, which is bound to image{Width,Height}'s change
events, but I've found that the change events don't always act
fast enough to validate the values before they're sent down
to ImageProcessor and cause an exception. That being said, I
was thinking proper input validation was a task to be completed
in another branch and not this one.