### PR TITLE
hotfix/hamburger

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@
         fluid
         class="full-height"
       >
-        <Settings @imageLoaded="passImage" v-if="showDrawer"></Settings>
+        <Settings @imageLoaded="passImage" v-show="showDrawer"></Settings>
       </v-container>
     </v-content>
   </v-app>


### PR DESCRIPTION
Fixes #64 

By switching from `v-if` to `v-show` to show/hide the settings panel, the elements are still present in the DOM, just hidden by CSS.

